### PR TITLE
Remove font import from app.scss file

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Raleway:300,400,600);/*
+/*
     Colorbox Core Style:
     The following CSS is consistent between example themes and should not be altered.
 */

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
     "/js/app.js": "/js/app.js?id=ade7df37dbe77763ed49",
-    "/css/app.css": "/css/app.css?id=aba8e02e835c2cbd6bce",
+    "/css/app.css": "/css/app.css?id=ed6551d6cff21987b21d",
     "/js/vendor.js": "/js/vendor.js?id=954deeca42f29b3ffde6",
     "/js/manifest.js": "/js/manifest.js?id=360cf4a2ac3af2c3da19"
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,7 +1,3 @@
-
-// Fonts
-@import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
-
 // Functions
 @import "~bootstrap/scss/functions";
 


### PR DESCRIPTION
For the 90%+ of the cases we want the `<link>` tag. As a rule of thumb, you want to avoid `@import` rules because they defer the loading of the included resource until the file is fetched.